### PR TITLE
feat: migrer til Jackson 3.x (tools.jackson)

### DIFF
--- a/oauth2-klient/src/main/kotlin/no/nav/dagpenger/oauth2/HttpClient.kt
+++ b/oauth2-klient/src/main/kotlin/no/nav/dagpenger/oauth2/HttpClient.kt
@@ -1,14 +1,13 @@
 package no.nav.dagpenger.oauth2
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.ProxyBuilder
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.http
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 
 @JvmOverloads
 fun defaultHttpClient(
@@ -22,8 +21,9 @@ fun defaultHttpClient(
     expectSuccess = true
     install(ContentNegotiation) {
         jackson {
-            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            changeDefaultPropertyInclusion {
+                JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.USE_DEFAULTS)
+            }
         }
     }
 }

--- a/oauth2-klient/src/test/kotlin/no/nav/dagpenger/client/OAuth2ClientTest.kt
+++ b/oauth2-klient/src/test/kotlin/no/nav/dagpenger/client/OAuth2ClientTest.kt
@@ -1,6 +1,6 @@
 package no.nav.dagpenger.client
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 import com.natpryce.konfig.ConfigurationMap
 import io.kotest.matchers.shouldBe
 import io.ktor.client.engine.mock.MockEngine
@@ -35,7 +35,7 @@ class OAuth2ClientTest {
             emptyMap(),
         )
 
-    private val tokenJsonString: String = jacksonObjectMapper().writeValueAsString(accessTokenResponse)
+    private val tokenJsonString: String = jacksonMapperBuilder().build().writeValueAsString(accessTokenResponse)
 
     @Test
     fun `AzureAD ClientCredentials client should call correct service with formparameters from configuration`() {

--- a/oauth2-klient/src/test/kotlin/no/nav/dagpenger/client/OAuth2ClientTest.kt
+++ b/oauth2-klient/src/test/kotlin/no/nav/dagpenger/client/OAuth2ClientTest.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.client
 
-import tools.jackson.module.kotlin.jacksonMapperBuilder
 import com.natpryce.konfig.ConfigurationMap
 import io.kotest.matchers.shouldBe
 import io.ktor.client.engine.mock.MockEngine
@@ -16,6 +15,7 @@ import no.nav.dagpenger.oauth2.defaultHttpClient
 import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenResponse
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 
 class OAuth2ClientTest {
     private val azureAdEnv =

--- a/pdl-klient-kobby/build.gradle.kts
+++ b/pdl-klient-kobby/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.20")
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations:2.21")
 }
 
 java {

--- a/pdl-klient/build.gradle.kts
+++ b/pdl-klient/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.client.cio)
     implementation(libs.ktor.serialization.jackson)
-    implementation(libs.jackson.datatype.jsr310)
     testImplementation("org.junit.jupiter:junit-jupiter-api:${libs.versions.junit.get()}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${libs.versions.junit.get()}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/pdl-klient/src/main/kotlin/no/nav/dagpenger/pdl/adapter/KtorHttpClientAdapter.kt
+++ b/pdl-klient/src/main/kotlin/no/nav/dagpenger/pdl/adapter/KtorHttpClientAdapter.kt
@@ -1,8 +1,6 @@
 package no.nav.dagpenger.pdl.adapter
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
@@ -18,12 +16,14 @@ import io.ktor.client.request.url
 import io.ktor.http.ContentType
 import io.ktor.http.Url
 import io.ktor.http.contentType
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import no.nav.dagpenger.pdl.PDLPerson
 import no.nav.dagpenger.pdl.PdlAdapter
 import no.nav.dagpenger.pdl.dto.QueryDto
 import no.nav.dagpenger.pdl.dto.graphql.PdlQueryResult
 import no.nav.dagpenger.pdl.dto.graphql.PdlRequest
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy
 import kotlin.time.Duration.Companion.seconds
 
 class KtorHttpClientAdapter(
@@ -67,9 +67,15 @@ fun proxyAwareHttpClient(
     HttpClient(engine) {
         install(ContentNegotiation) {
             jackson {
-                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                registerModules(JavaTimeModule())
+                accessorNaming(
+                    DefaultAccessorNamingStrategy
+                        .Provider()
+                        .withFirstCharAcceptance(true, true),
+                )
+                disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                changeDefaultPropertyInclusion {
+                    JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.USE_DEFAULTS)
+                }
             }
         }
         install(HttpTimeout) {

--- a/pdl-klient/src/test/kotlin/no/nav/dagpenger/pdl/ClientTest.kt
+++ b/pdl-klient/src/test/kotlin/no/nav/dagpenger/pdl/ClientTest.kt
@@ -3,8 +3,6 @@
 package no.nav.dagpenger.pdl
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -13,12 +11,14 @@ import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.oauth2.CachedOauth2Client
 import no.nav.dagpenger.oauth2.OAuth2Config
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy
 
 @Disabled("Manuel test")
 class ClientTest {
@@ -56,9 +56,15 @@ class ClientTest {
         HttpClient(CIO) {
             install(ContentNegotiation) {
                 jackson {
-                    configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                    registerModules(JavaTimeModule())
-                    setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                    accessorNaming(
+                        DefaultAccessorNamingStrategy
+                            .Provider()
+                            .withFirstCharAcceptance(true, true),
+                    )
+                    disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+                    changeDefaultPropertyInclusion {
+                        JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.USE_DEFAULTS)
+                    }
                 }
             }
             defaultRequest {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20251205.234.05353f")
+            from("no.nav.dagpenger:dp-version-catalog:20260430.250.40dd8b")
         }
     }
 }

--- a/sts-klient/src/main/kotlin/no/nav/dagpenger/oidc/StsOidcClient.kt
+++ b/sts-klient/src/main/kotlin/no/nav/dagpenger/oidc/StsOidcClient.kt
@@ -14,7 +14,7 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import io.prometheus.client.Summary
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking

--- a/texas-klient/src/main/kotlin/no/nav/dagpenger/texas/HttpClient.kt
+++ b/texas-klient/src/main/kotlin/no/nav/dagpenger/texas/HttpClient.kt
@@ -1,8 +1,6 @@
 package no.nav.dagpenger.texas
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.module.SimpleModule
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
@@ -15,7 +13,8 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpStatusCode
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
+import tools.jackson.databind.module.SimpleModule
 
 fun defaultHttpClient(
     httpClientEngine: HttpClientEngine = CIO.create {},
@@ -25,9 +24,10 @@ fun defaultHttpClient(
 
     install(ContentNegotiation) {
         jackson {
-            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            setSerializationInclusion(JsonInclude.Include.NON_NULL)
-            registerModules(
+            changeDefaultPropertyInclusion {
+                JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.USE_DEFAULTS)
+            }
+            addModule(
                 SimpleModule().also {
                     it.addDeserializer(IntrospectResponse::class.java, IntrospectResponseDeserializer)
                 },

--- a/texas-klient/src/main/kotlin/no/nav/dagpenger/texas/IntrospectResponseDeserializer.kt
+++ b/texas-klient/src/main/kotlin/no/nav/dagpenger/texas/IntrospectResponseDeserializer.kt
@@ -1,17 +1,17 @@
 package no.nav.dagpenger.texas
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
+import tools.jackson.core.JsonParser
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.ValueDeserializer
 
-object IntrospectResponseDeserializer : JsonDeserializer<IntrospectResponse>() {
+object IntrospectResponseDeserializer : ValueDeserializer<IntrospectResponse>() {
     override fun deserialize(
         p: JsonParser,
         ctxt: DeserializationContext,
     ): IntrospectResponse {
         return kotlin.runCatching {
-            val map = p.codec.readValue(p, object : TypeReference<Map<String, Any>>() {})
+            val map = p.readValueAs(object : TypeReference<Map<String, Any>>() {})
             when (map["active"] as Boolean) {
                 true -> {
                     IntrospectResponse.Valid(

--- a/texas-klient/src/test/kotlin/no/nav/dagpenger/texas/IntrospectResponseDeserializerTest.kt
+++ b/texas-klient/src/test/kotlin/no/nav/dagpenger/texas/IntrospectResponseDeserializerTest.kt
@@ -1,19 +1,18 @@
 package no.nav.dagpenger.texas
 
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.module.SimpleModule
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 
 class IntrospectResponseDeserializerTest {
     private val mapper =
-        jacksonObjectMapper().also {
-            val simpleModule =
+        jacksonMapperBuilder()
+            .addModule(
                 SimpleModule().also {
                     it.addDeserializer(IntrospectResponse::class.java, IntrospectResponseDeserializer)
-                }
-            it.registerModule(simpleModule)
-        }
+                },
+            ).build()
 
     @Test
     fun `deserialize valid response`() {


### PR DESCRIPTION
## Hva er endret?

Migrerer alle moduler fra Jackson 2 til Jackson 3 for å fikse `Conflicting property-based creators` runtime-feil i downstream-repoer (f.eks. dp-saksbehandling).

### Endrede moduler

| Modul | Endring |
|-------|---------|
| `pdl-klient-kobby` | jackson-annotations 2.20 → 2.21 |
| `pdl-klient` | `ktor-serialization-jackson3`, `withFirstCharAcceptance`, fjern JavaTimeModule |
| `oauth2-klient` | `ktor-serialization-jackson3`, fjern `configure()` (immutable i J3) |
| `texas-klient` | `ValueDeserializer`, `readValueAs`, `jackson3` plugin |
| `sts-klient` | `jackson3` plugin |

### Hvorfor?

Kobby-genererte DTOs (pdl-klient-kobby) får `@JsonCreator` på både primær- og no-arg-konstruktør. Jackson 2 tolererer dette, men Jackson 3 kaster:

```
Conflicting property-based creators: already had explicit creator
[constructor for UkjentBostedDto (0 args)],
encountered another: [constructor for UkjentBostedDto (1 arg)]
```

Ved å kompilere med Jackson 3 Kotlin-module brukes riktig creator-deteksjon.

### Jackson 3 default-endringer

Tre innstillinger har endret default-verdi i Jackson 3. Alle mappere er gjennomgått:

| Innstilling | Jackson 2 default | Jackson 3 default | Konsekvens |
|---|---|---|---|
| `FAIL_ON_UNKNOWN_PROPERTIES` | **PÅ** | **AV** | Ukjente felter ignoreres nå uten eksplisitt config |
| `WRITE_DATES_AS_TIMESTAMPS` | **PÅ** (epoch-tall) | **AV** (ISO-streng) | Datoer serialiseres som `"2026-05-04"` uten eksplisitt config |
| `JavaTimeModule` | Må registreres manuelt | **Innebygd** | Fjernet alle `registerModules(JavaTimeModule())` |

**Konsekvens per mapper:**

| Mapper | `FAIL_ON` | `DATES_AS_TS` | Vurdering |
|---|---|---|---|
| **oauth2** | Var eksplisitt AV → fjernet (nå default) ✅ | Ikke relevant (ingen datoer) ✅ | OK |
| **pdl** | Var eksplisitt AV → fjernet (nå default) ✅ | Eksplisitt AV (redundant men trygt) ✅ | OK |
| **texas** | Var eksplisitt AV → fjernet (nå default) ✅ | Ikke relevant ✅ | OK |
| **sts** | Var ikke satt (default PÅ i J2) → nå AV i J3 | Ikke relevant ✅ | OK — STS-respons er enkel, ekstra felter ignoreres trygt |

### Version catalog

Bumper til `dp-version-catalog:20260430.250.40dd8b` (Jackson 3.1.2, Ktor 3.4.3).